### PR TITLE
Removed Parentheses in Declaring the Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small extension for Caliburn.Micro which enables fluent builder style validati
 For example: 
 
 ```C#
-public class PaymentEditorViewModel() : ValidatingScreen
+public class PaymentEditorViewModel : ValidatingScreen
 {
   public PaymentEditorViewModel()
   {


### PR DESCRIPTION
Seems you've made a typo there. You wrote

```
    public class PaymentEditorViewModel() : ValidatingScreen
```
and it shouldn't contain the parentheses.